### PR TITLE
Download archive for siege down

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,13 +32,25 @@ jobs:
       - name: Get latest Siege version
         id: get-version
         run: |
-          LATEST_VERSION=$(curl -s https://download.joedog.org/siege/ | grep -oP 'siege-\K[0-9.]+(?=\.tar\.gz)' | sort -V | tail -n 1)
+          LATEST_TAG=$(git ls-remote --tags --sort='-v:refname' https://github.com/JoeDog/siege.git | \
+            grep -E 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' | \
+            head -n 1 | \
+            cut -d/ -f3)
+
+            if [[ $LATEST_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "latest_tag=$LATEST_TAG" >> "$GITHUB_ENV"
+            else
+              echo "No valid release tag found"
+              exit 1
+            fi
+          LATEST_VERSION=$(echo $LATEST_TAG | cut -d 'v' -f2)
           echo "latest_version=${LATEST_VERSION}" >> "$GITHUB_ENV"
           echo "major_version=$(echo ${LATEST_VERSION} | cut -d. -f1)" >> "$GITHUB_ENV"
           echo "minor_version=$(echo ${LATEST_VERSION} | cut -d. -f1-2)" >> "$GITHUB_ENV"
 
       - name: Display siege version
         run: |
+          echo "The latest git tag of Siege is ${{ env.latest_tag }}"
           echo "The latest version of Siege is ${{ env.latest_version }}"
           echo "The latest major version of Siege is ${{ env.major_version }}"
           echo "The latest minior version of Siege is ${{ env.minor_version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,26 +8,28 @@ RUN set -ex && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
   build-essential \
+  automake \
   libssl-dev \
   zlib1g-dev \
   curl \
   ca-certificates \
+  git \
   libssl3 && \
-  curl -O -L http://download.joedog.org/siege/siege-${SIEGE_VERSION}.tar.gz && \
-  tar -xvzf siege-${SIEGE_VERSION}.tar.gz && \
-  cd siege-${SIEGE_VERSION} && \
+  git clone --depth 1 --branch v${SIEGE_VERSION} https://github.com/JoeDog/siege.git && \
+  cd siege && \
+  ./utils/bootstrap && \
   ./configure && \
   make && \
   make install
 
 FROM debian:bookworm-slim
 
-COPY --from=builder /app/siege-*/src/siege /usr/local/bin/siege
-COPY --from=builder /app/siege-*/utils/siege.config /usr/local/bin/siege.config
-COPY --from=builder /app/siege-*/utils/siege2csv.pl /usr/local/bin/siege2csv
-COPY --from=builder /app/siege-*/utils/bombardment /usr/local/bin/bombardment
-COPY --from=builder /app/siege-*/doc/siegerc /etc/siegerc
-COPY --from=builder /app/siege-*/COPYING /SIEGE-COPYING
+COPY --from=builder /app/siege/src/siege /usr/local/bin/siege
+COPY --from=builder /app/siege/utils/siege.config /usr/local/bin/siege.config
+COPY --from=builder /app/siege/utils/siege2csv.pl /usr/local/bin/siege2csv
+COPY --from=builder /app/siege/utils/bombardment /usr/local/bin/bombardment
+COPY --from=builder /app/siege/doc/siegerc /etc/siegerc
+COPY --from=builder /app/siege/COPYING /SIEGE-COPYING
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get install -y --no-install-recommends libssl3 ca-certificates zlib1g && \


### PR DESCRIPTION
Switch to use github repo instead of release archive for siege builds.

![image](https://github.com/user-attachments/assets/b54a91a3-de04-4ff4-b959-63e7c50ecb37)
